### PR TITLE
Feature analytics: Basic custom events - Firebase

### DIFF
--- a/ff.web/src/components/pages/GamePlayerPage.tsx
+++ b/ff.web/src/components/pages/GamePlayerPage.tsx
@@ -4,6 +4,9 @@ import mockRecipe from '@static/mockRecipe';
 import mockQuizData from '@static/mockQuizData';
 import games from '../organisms/GamePlayer';
 import styles from './Minigames.module.scss';
+import { analytics } from '../../config/firebase';
+import { logEvent } from 'firebase/analytics';
+import { useState } from 'react';
 
 interface GamePageState {
     questId?: string;
@@ -27,20 +30,35 @@ function GamePlayerPage() {
         return null;
     }
 
-    const quiz = quizId 
-        ? mockQuizData.find(q => q.id === quizId) 
-        : mockQuizData[Math.floor(Math.random() * mockQuizData.length)];
+    const [startTime] = useState(Date.now());
+
+    const handleGameComplete = (gameResult: any) => {
+        const duration = Date.now() - startTime;
+        logEvent(analytics, 'minigame_completed', {
+            game_id: gameId,
+            game_name: game.name,
+            quest_id: questId,
+            score: gameResult?.score,
+            duration: duration,
+            success: gameResult?.wasSuccessful
+        });
+    };
 
     const onClose = () => {
         if (questId) {
+            handleGameComplete({ wasSuccessful: true }); // Log the game completion
             const completedQuestIds = JSON.parse(localStorage.getItem('completedQuestIds') || '[]')
             localStorage.setItem('completedQuestIds', JSON.stringify([...completedQuestIds, questId]))
         }
         navigate(-1);
     };
 
+    const quiz = quizId 
+        ? mockQuizData.find(q => q.id === quizId) 
+        : mockQuizData[Math.floor(Math.random() * mockQuizData.length)];
+
     const GameComponent = game.component;
-    
+
     return (
         <div className={styles.minigames_container}>
             <Button onClick={() => navigate(-1)} className={styles.back_button}>
@@ -52,7 +70,7 @@ function GamePlayerPage() {
                 recipe={mockRecipe}
                 quiz={quiz!}
                 presetAnimal={animal as 'Cow' | 'Chicken' | 'Pig'}
-                onClose={onClose} 
+                onClose={onClose}
             />
         </div>
     );

--- a/ff.web/src/components/pages/QuestIntro.tsx
+++ b/ff.web/src/components/pages/QuestIntro.tsx
@@ -17,6 +17,8 @@ import { ChannelUser } from "@vuo/stores/WebSocketStore";
 import PlayerItem from '@vuo/organisms/PlayerItem';
 
 import soundFile from '@vuo/assets/sounds/swishh.mp3';
+import { analytics } from '../../config/firebase';
+import { logEvent } from 'firebase/analytics';
 
 const QuestIntro = observer(() => {
   const navigate = useNavigate();

--- a/ff.web/src/components/pages/QuestOutro.tsx
+++ b/ff.web/src/components/pages/QuestOutro.tsx
@@ -102,12 +102,12 @@ const QuestOutro = observer(() => {
   }, [viewModel.playerAchievementsForCompletedQuest]);
 
   useEffect(() => {
-    // Track quest completion
     if (viewModel.playerQuest) {
+      // Track quest completion
       logEvent(analytics, 'quest_completed', {
         quest_id: viewModel.playerQuest.id,
         quest_name: viewModel.playerQuest.name,
-        quest_duration: viewModel.playerQuest.duration, // You'll need to add this to your Quest model
+        // quest_duration: viewModel.playerQuest.duration, // You'll need to add this to your Quest model
         xp_earned: viewModel.combinedPlayerSkillsForCompletedQuest?.reduce(
           (prevValue, { challenge_rating }) => prevValue + challenge_rating, 
           0
@@ -115,8 +115,31 @@ const QuestOutro = observer(() => {
         achievements_earned: viewModel.playerAchievementsForCompletedQuest?.length || 0,
         skills_earned: viewModel.combinedPlayerSkillsForCompletedQuest?.map(skill => skill.name) || [],
       });
+
+      // Track individual achievements
+      viewModel.playerAchievementsForCompletedQuest?.forEach(achievement => {
+        logEvent(analytics, 'achievement_unlocked', {
+          achievement_id: achievement.achievement.id,
+          achievement_name: achievement.achievement.name,
+          quest_id: viewModel.playerQuest.id,
+          quest_name: viewModel.playerQuest.name,
+          achievement_type: achievement.achievement.type, // if you have achievement types
+          achievement_description: achievement.achievement.description,
+          achievement_xp: achievement.achievement.xpValue // if achievements have XP values
+        });
+      });
+
+      // Track skills gained
+      viewModel.combinedPlayerSkillsForCompletedQuest?.forEach(skill => {
+        logEvent(analytics, 'skill_gained', {
+          skill_name: skill.name,
+          skill_xp: skill.challenge_rating,
+          quest_id: viewModel.playerQuest.id,
+          quest_name: viewModel.playerQuest.name
+        });
+      });
     }
-  }, [viewModel.playerQuest]);
+  }, [viewModel.playerQuest, viewModel.playerAchievementsForCompletedQuest, viewModel.combinedPlayerSkillsForCompletedQuest]);
 
   // const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
   //   event.preventDefault();

--- a/ff.web/src/components/pages/QuestOutro.tsx
+++ b/ff.web/src/components/pages/QuestOutro.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useState, CSSProperties, useRef } from 'react';
 import { observer } from 'mobx-react-lite'
 import { useNavigate, useParams } from 'react-router-dom';
+import { analytics } from '../../config/firebase';
+import { logEvent } from 'firebase/analytics';
 
 // import AchievementOutro from '@vuo/molecyles/AchievementOutro';
 import Button from '@vuo/atoms/Button';
@@ -98,6 +100,23 @@ const QuestOutro = observer(() => {
       clearInterval(intervalId);
     };
   }, [viewModel.playerAchievementsForCompletedQuest]);
+
+  useEffect(() => {
+    // Track quest completion
+    if (viewModel.playerQuest) {
+      logEvent(analytics, 'quest_completed', {
+        quest_id: viewModel.playerQuest.id,
+        quest_name: viewModel.playerQuest.name,
+        quest_duration: viewModel.playerQuest.duration, // You'll need to add this to your Quest model
+        xp_earned: viewModel.combinedPlayerSkillsForCompletedQuest?.reduce(
+          (prevValue, { challenge_rating }) => prevValue + challenge_rating, 
+          0
+        ),
+        achievements_earned: viewModel.playerAchievementsForCompletedQuest?.length || 0,
+        skills_earned: viewModel.combinedPlayerSkillsForCompletedQuest?.map(skill => skill.name) || [],
+      });
+    }
+  }, [viewModel.playerQuest]);
 
   // const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
   //   event.preventDefault();

--- a/ff.web/src/components/pages/QuestPlay.tsx
+++ b/ff.web/src/components/pages/QuestPlay.tsx
@@ -21,6 +21,8 @@ import QuestTask from "../organisms/QuestTask";
 import QuestProgressBar from "../molecules/QuestProgressBar";
 // import QuestChallenge from "../organisms/QuestChallenge";
 
+import { analytics } from '../../config/firebase';
+import { logEvent } from 'firebase/analytics';
 
 const QuestPlay = observer(() => {
   const { id } = useParams();
@@ -67,6 +69,17 @@ const QuestPlay = observer(() => {
           behavior: "smooth",
         });
       }
+    }
+
+    if (viewModel.playerQuest) {
+      // Track quest start
+      logEvent(analytics, 'quest_started', {
+        quest_id: viewModel.playerQuest.id,
+        quest_name: viewModel.playerQuest.name,
+        // player_level: viewModel.playerLevel, // You'll need to add this to your viewModel
+        // player_total_xp: viewModel.playerTotalXP, // You'll need to add this to your viewModel
+        // is_retry: viewModel.isRetry // You'll need to add this to your viewModel
+      });
     }
   }, [
     viewModel.playerQuest?.state,


### PR DESCRIPTION
[Analytics] Add  custom events tracking for the following: 

Changes made:
1. ff.web/src/components/pages/GamePlayerPage.tsx
   - Added minigame completion tracking
   - Added handleGameComplete function
   - Integrated analytics with onClose

2. ff.web/src/components/pages/QuestPlay.tsx
   - Added quest_started event tracking
   - Added analytics imports

3. ff.web/src/components/pages/QuestOutro.tsx
   - Added quest completion tracking
   - Added achievements tracking
   - Added skills gained tracking // even if we don't have the functionality for skills atm. 



Key analytics events added:
- quest_started
- quest_completed
- minigame_completed
- achievement_unlocked
- skill_gained

Each event includes relevant contextual data like IDs, names, durations, and success metrics.